### PR TITLE
support for wrapping xsd:any. code for #10 (was unable to fix test)

### DIFF
--- a/src/main/java/com/sun/tools/xjc/addon/xew/XmlElementWrapperPlugin.java
+++ b/src/main/java/com/sun/tools/xjc/addon/xew/XmlElementWrapperPlugin.java
@@ -684,7 +684,7 @@ public class XmlElementWrapperPlugin extends Plugin {
 
 			// * The only one parametrisation type should not be java.lang.Object (the case for <xs:any>)
 			//   or java.io.Serializable / javax.xml.bind.JAXBElement (the case for <xs:complexType ... mixed="true">)
-			if (isTopClass(fieldParametrisations.get(0))) {
+			if (/*!fieldParametrisations.get(0).erasure().fullName().equals(Object.class.getName()) && */isTopClass(fieldParametrisations.get(0))) {
 				continue;
 			}
 


### PR DESCRIPTION
The change was tested on a schema (wsdl) containing xs:any wrapped elements, as well as other wrapped types.
