### PR TITLE
issue-12 sample

### DIFF
--- a/samples/jaxb-xew-plugin-issue-12/pom.xml
+++ b/samples/jaxb-xew-plugin-issue-12/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.jvnet.jax-ws-commons</groupId>
+	<artifactId>jaxb-xew-plugin-issue-12</artifactId>
+	<version>0.1</version>
+	<name>Test for jaxb-xew-plugin issue 12</name>
+	<packaging>jar</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.0</version>
+
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+					<encoding>UTF-8</encoding>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.jvnet.jax-ws-commons</groupId>
+				<artifactId>jaxws-maven-plugin</artifactId>
+				<version>2.3.1-b03</version>
+
+				<executions>
+					<execution>
+						<id>generate-stubs</id>
+						<goals>
+							<goal>wsimport</goal>
+						</goals>
+
+						<configuration>
+							<xjcArgs>
+								<xjcArg>-no-header</xjcArg>
+								<xjcArg>-Xxew</xjcArg>
+								<xjcArg>-Xxew:instantiate lazy</xjcArg>
+								<!-- https://github.com/dmak/jaxb-xew-plugin/issues/12 -->
+								<xjcArg>-Xxew:delete</xjcArg>
+							</xjcArgs>
+
+							<sourceDestDir>${project.build.directory}/generated-sources/jaxws/wsimport/java</sourceDestDir>
+							<wsdlDirectory>src/main/resources</wsdlDirectory>
+
+							<extension>true</extension>
+
+							<keep>true</keep>
+						</configuration>
+					</execution>
+				</executions>
+
+				<dependencies>
+					<dependency>
+						<groupId>com.sun.xml.ws</groupId>
+						<artifactId>jaxws-tools</artifactId>
+						<version>2.2.8</version>
+
+						<exclusions>
+							<exclusion>
+								<groupId>org.jvnet.staxex</groupId>
+								<artifactId>stax-ex</artifactId>
+							</exclusion>
+						</exclusions>
+					</dependency>
+					<dependency>
+						<groupId>com.github.jaxb-xew-plugin</groupId>
+						<artifactId>jaxb-xew-plugin</artifactId>
+						<version>1.1</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies/>
+</project>

--- a/samples/jaxb-xew-plugin-issue-12/src/main/resources/test.wsdl
+++ b/samples/jaxb-xew-plugin-issue-12/src/main/resources/test.wsdl
@@ -1,0 +1,48 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-stylesheet type="text/xsl" href="wsdl-viewer.xsl"?>
+<wsdl:definitions xmlns="http://jax-ws-commons.jvnet.org/test" targetNamespace="http://jax-ws-commons.jvnet.org/test"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  name="testService">
+	<wsdl:types>
+		<xsd:schema>
+			<xsd:import namespace="http://jax-ws-commons.jvnet.org/test" schemaLocation="test.xsd"/>
+		</xsd:schema>
+	</wsdl:types>
+
+	<wsdl:message name="listReqMsg">
+		<wsdl:part name="parameters" element="listRequest"/>
+	</wsdl:message>
+	<wsdl:message name="listRespMsg">
+		<wsdl:part name="parameters" element="listResponse"/>
+	</wsdl:message>
+
+	<wsdl:portType name="testPort">
+		<wsdl:operation name="list">
+			<wsdl:input message="listReqMsg"/>
+			<wsdl:output message="listRespMsg"/>
+		</wsdl:operation>
+	</wsdl:portType>
+
+	<wsdl:binding name="testBinding" type="testPort">
+		<soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+
+		<wsdl:operation name="list">
+			<soap:operation soapAction=""/>
+
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+
+	<wsdl:service name="testService">
+		<wsdl:port name="testPort" binding="testBinding">
+			<soap:address location="REPLACE_WITH_ACTUAL_URL"/>
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>

--- a/samples/jaxb-xew-plugin-issue-12/src/main/resources/test.xsd
+++ b/samples/jaxb-xew-plugin-issue-12/src/main/resources/test.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://jax-ws-commons.jvnet.org/test" targetNamespace="http://jax-ws-commons.jvnet.org/test"
+            xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified" attributeFormDefault="unqualified"
+            jaxb:version="2.1"
+            version="1.0">
+	<xsd:element name="listRequest" type="listRequest"/>
+	<xsd:element name="listResponse" type="listResponse"/>
+
+	<xsd:complexType name="listRequest">
+		<xsd:sequence/>
+	</xsd:complexType>
+
+	<xsd:complexType name="listResponse">
+		<xsd:sequence>
+			<xsd:annotation>
+				<xsd:appinfo>
+					<jaxb:property name="items"/>
+				</xsd:appinfo>
+			</xsd:annotation>
+
+			<xsd:element name="item" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>


### PR DESCRIPTION
This is the sample to reproduce https://github.com/dmak/jaxb-xew-plugin/issues/12.
I use command `mvn clean generate-sources` to build project.
If we use `-Xxew:delete` option we'll get empty respose class (`ListResponse.java`), but expect to see this field:

``` java
@XmlElement(name = "item")
protected List<String> items;
```
