### PR TITLE
Preserve nillable annotation attribute

### DIFF
--- a/src/main/java/com/sun/tools/xjc/addon/xew/XmlElementWrapperPlugin.java
+++ b/src/main/java/com/sun/tools/xjc/addon/xew/XmlElementWrapperPlugin.java
@@ -478,6 +478,12 @@ public class XmlElementWrapperPlugin extends Plugin {
 					xmlElementWrapperAnnotation.param("required", warpperXmlRequired);
 				}
 
+				JExpression warpperXmlNillable = getAnnotationMemberExpression(originalImplField, xmlElementModelClass,
+				            "nillable");
+				if (warpperXmlNillable != null) {
+					xmlElementWrapperAnnotation.param("nillable", warpperXmlNillable);
+				}
+
 				// Namespace of the wrapper element
 				JExpression wrapperXmlNamespace = getAnnotationMemberExpression(originalImplField,
 				            xmlElementModelClass, "namespace");


### PR DESCRIPTION
Currently this:

```
@XmlElement(nillable = true)
protected ArrayOfstring field;
```

Becomes this:

```
@XmlElementWrapper(name = "field")
@XmlElement(name = "string", namespace = "http://schemas.microsoft.com/2003/10/Serialization/Arrays")
protected List<String> field;
```

Which changes serialization behavior for null values. Attached commit fixes the problem.
